### PR TITLE
PADV 1126 - lock the username column when scrolling to the right

### DIFF
--- a/src/components/GradesView/GradesView.scss
+++ b/src/components/GradesView/GradesView.scss
@@ -122,3 +122,51 @@ select#ScoreView.form-control {
         border-right-color: $black;
     }
 }
+
+// Table First column and Header fixer.
+
+// These overflow configs are needed for the sticky to work.
+.pgn__data-table-container {
+  overflow-x: initial;
+  overflow-y: initial;
+}
+
+.pgn__data-table-layout-wrapper {
+  overflow-x: initial;
+}
+
+.pgn__data-table thead tr {
+  position: relative;
+}
+
+.pgn__data-table thead tr th,
+.pgn__data-table tbody tr td {
+  z-index: 0;
+}
+
+.pgn__data-table thead tr th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.pgn__data-table thead tr th:first-child {
+  z-index: 3;
+  left: 0;
+}
+
+.pgn__data-table tbody tr td:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  box-shadow: 0 0 7px 5px rgba(0, 0, 0, 0.1);
+  clip-path: inset(0px -15px 0px 0px);
+}
+
+.pgn__data-table tbody tr:nth-child(odd) td {
+  background-color: white;
+}
+
+.pgn__data-table tbody tr:nth-child(even) td {
+  background-color: $light-200;
+}


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-1126

## Description

This PR aims to lock the username column and the header when scrolling through the gradebook table. The approach take was to do the functionality with CSS since the DataTable component from Paragon didn't have an option to lock a column.

## Screenshots

[Screencast from 02-04-24 11:36:35.webm](https://github.com/Pearson-Advance/frontend-app-gradebook/assets/62396424/73d97022-e952-490a-9993-58e1719bffaa)

## How to test?

- Setup devstack
- Add to gradebook repo this remote and checkout to this branch.
- Create a graded course with enough assignments for the scroll to appear.
- Verify that the username column and the header are locked when scrolling.