### PR TITLE
feat: add full name field to gradebook table data mapping

### DIFF
--- a/src/components/GradesView/GradebookTable/hooks.jsx
+++ b/src/components/GradesView/GradebookTable/hooks.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { getConfig } from '@edx/frontend-platform';
 import { useIntl } from '@edx/frontend-platform/i18n';
 
 import { selectors } from 'data/redux/hooks';
@@ -18,6 +19,14 @@ export const useGradebookTableData = () => {
   const { formatMessage } = useIntl();
   const grades = selectors.grades.useAllGrades();
   const headings = selectors.root.useGetHeadings();
+  const { GRADEBOOK_TABLE_ENABLE_FULL_NAME: enableFullName = false } = getConfig() ?? {};
+
+  const filteredHeadings = headings.filter((heading) => {
+    if (enableFullName) {
+      return heading !== Headings.username;
+    }
+    return heading !== Headings.fullName;
+  });
 
   const mapHeaders = (heading) => {
     let label;
@@ -35,22 +44,32 @@ export const useGradebookTableData = () => {
     return { Header: label, accessor: heading };
   };
 
-  const mapRows = entry => ({
-    [Headings.username]: (
-      <Fields.Username username={entry.username} userKey={entry.external_user_key} />
-    ),
-    [Headings.email]: (<Fields.Text value={entry.email} />),
-    [Headings.totalGrade]: `${roundGrade(entry.percent * 100)}${getLocalizedPercentSign()}`,
-    ...entry.section_breakdown.reduce((acc, subsection) => ({
-      ...acc,
-      [subsection.label]: <GradeButton {...{ entry, subsection }} />,
-    }), {}),
-  });
+  const mapRows = (entry) => {
+    const usernameOrFullName = enableFullName
+      ? {
+        [Headings.fullName]: <Fields.Text value={entry?.full_name || ''} />,
+      }
+      : {
+        [Headings.username]: (
+          <Fields.Username username={entry.username} userKey={entry.external_user_key} />
+        ),
+      };
+
+    return {
+      ...usernameOrFullName,
+      [Headings.email]: <Fields.Text value={entry.email} />,
+      [Headings.totalGrade]: `${roundGrade(entry.percent * 100)}${getLocalizedPercentSign()}`,
+      ...entry.section_breakdown.reduce((acc, subsection) => ({
+        ...acc,
+        [subsection.label]: <GradeButton {...{ entry, subsection }} />,
+      }), {}),
+    };
+  };
 
   const nullMethod = () => null;
 
   return {
-    columns: headings.map(mapHeaders),
+    columns: filteredHeadings.map(mapHeaders),
     data: grades.map(mapRows),
     grades,
     nullMethod,

--- a/src/components/GradesView/GradebookTable/hooks.test.jsx
+++ b/src/components/GradesView/GradebookTable/hooks.test.jsx
@@ -77,7 +77,6 @@ const headings = [
   Headings.totalGrade,
   Headings.username,
   Headings.email,
-  Headings.fullName,
   testHeading,
 ];
 


### PR DESCRIPTION
# Description
In this PR is added `full_name` into the gradebook column.

## Ticket
https://pearson.atlassian.net/browse/PADV-3269

## Screenshots
_before_
<img width="1440" height="693" alt="Screenshot 2026-06-03 at 12 13 26 PM" src="https://github.com/user-attachments/assets/a598cb45-ac2f-4815-9e7d-e1da95851243" />

_after_
_flag enabled_
<img width="1435" height="448" alt="Screenshot 2026-06-04 at 11 54 33 AM" src="https://github.com/user-attachments/assets/e213bbd5-0ac0-413b-9ad5-973b0375c574" />

_flag_disabled_
<img width="1446" height="482" alt="Screenshot 2026-06-04 at 11 54 42 AM" src="https://github.com/user-attachments/assets/31e9d1a0-3eca-4555-9aab-76076528875f" />

## How to test
Add `GRADEBOOK_TABLE_ENABLE_FULL_NAME` in the site configurations.




